### PR TITLE
Fix: Ensure Hero section text visibility in light mode

### DIFF
--- a/portfolio/src/App.jsx
+++ b/portfolio/src/App.jsx
@@ -133,9 +133,9 @@ function App() {
         </Parallax>
 
         <div className="container mx-auto px-4 relative z-10">
-          <motion.div initial={{ opacity: 0, y: 40 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }} className="max-w-2xl">
-            <h1 className="text-4xl md:text-5xl lg:text-6xl font-extrabold mb-4 text-white">Frontend Developer</h1>
-            <p className="text-lg md:text-xl text-gray-300 mb-8">Building responsive and scalable web applications with modern technologies. 3+ years of experience.</p>
+          <motion.div initial={{ opacity: 0, y: 40 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }} className={`max-w-2xl ${!isDarkMode ? 'bg-slate-100/80 backdrop-blur-md p-6 rounded-lg shadow-lg' : ''}`}>
+            <h1 className={`text-4xl md:text-5xl lg:text-6xl font-extrabold mb-4 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}>Frontend Developer</h1>
+            <p className={`text-lg md:text-xl mb-8 ${isDarkMode ? 'text-gray-300' : 'text-slate-700'}`}>Building responsive and scalable web applications with modern technologies. 3+ years of experience.</p>
             <div className="flex flex-wrap gap-4">
               <motion.button 
                 whileHover={{ scale: 1.05 }} 


### PR DESCRIPTION
This commit addresses the issue where the Hero section title and summary text were not clearly visible in light mode.

A conditional background panel has been added to the text container within the Hero section. In light mode, this panel provides a semi-transparent light background (`bg-slate-100/80 backdrop-blur-md p-6 rounded-lg shadow-lg`).

The text colors for the H1 title and the paragraph summary within the Hero section have also been made conditional:
- H1: `text-slate-900` in light mode, `text-white` in dark mode.
- Paragraph: `text-slate-700` in light mode, `text-gray-300` in dark mode.

These changes ensure that the Hero section text has good contrast and is clearly legible in both light and dark themes.